### PR TITLE
Implementing examples for simple infrastructures (List & Optics)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,12 +2,11 @@ name := "language-integrated_query"
 
 organization := "org.hablapps"
 
-inThisBuild(Seq(
-  scalaOrganization := "org.typelevel",
-  scalaVersion := "2.12.4-bin-typelevel-4"
-))
+scalaVersion := "2.12.7"
 
-addCompilerPlugin("io.tryp" % "splain" % "0.3.1" cross CrossVersion.patch)
+addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full)
+
+// addCompilerPlugin("io.tryp" % "splain" % "0.3.1" cross CrossVersion.patch)
 
 addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.3")
 
@@ -31,7 +30,11 @@ libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "3.2.3",
   "org.slf4j" % "slf4j-simple" % "1.6.4",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.2.3",
-  "mysql" % "mysql-connector-java" % "5.1.34")
+  "mysql" % "mysql-connector-java" % "5.1.34",
+  "com.github.julien-truffaut" %%  "monocle-core"  % "1.5.0",
+  "com.github.julien-truffaut" %%  "monocle-macro" % "1.5.0",
+  "com.github.julien-truffaut" %%  "monocle-law"   % "1.5.0" % "test"
+)
 
 javaOptions ++= Seq(
   "-Dquill.binds.log=true",

--- a/src/main/scala/ListComprehension.scala
+++ b/src/main/scala/ListComprehension.scala
@@ -1,0 +1,98 @@
+package org.hablapps.liq
+
+object ListComprehension {
+
+  case class Person(name: String, age: Int)
+  case class Couple(her: String, him: String)
+
+  type People  = List[Person]
+  type Couples = List[Couple]
+
+  val people = List(
+    Person("Alex", 60), 
+    Person("Bert", 55), 
+    Person("Cora", 33), 
+    Person("Drew", 31),
+    Person("Edna", 21),
+    Person("Fred", 60))
+
+  val couples = List(
+    Couple("Alex", "Bert"),
+    Couple("Cora", "Drew"),
+    Couple("Edna", "Fred"))
+
+  object Primitives {
+
+    val getPeople: People = people
+
+    val getPeopleName: List[String] = people.map(_.name)
+
+    val getPeopleOnTheirThirties: People =
+      for {
+        p <- people
+        if 30 <= p.age && p.age < 40
+      } yield p
+
+    val getHerAges: List[Int] =
+      for {
+        w <- people
+        n <- couples.map(_.her)
+        if w.name == n
+      } yield w.age
+  }
+
+  object QueryViaQuotation {
+    
+    val difference =
+      for {
+        c <- couples
+        w <- people
+        m <- people
+        if c.her == w.name && c.him == m.name && w.age > m.age
+      } yield (w.name, w.age - m.age)
+  }
+
+  object AbstractingOverValues {
+
+    val range = { (a: Int, b: Int) =>
+      for {
+        w <- people
+        if a <= w.age && w.age < b
+      } yield w.name
+    }
+
+    range(30, 40)
+  }
+
+  object AbstractingOverAPredicate {
+
+    val satisfies = { (p: Int => Boolean) =>
+      for {
+        w <- people
+        if p(w.age)
+      } yield w.name
+    }
+
+    satisfies(i => 30 <= i && i < 40)
+  }
+
+  object ComposingQueries {
+    import AbstractingOverValues.range
+    
+    val getAge = { (s: String) =>
+      for {
+        u <- people
+        if u.name == s
+      } yield u.age
+    }
+
+    val compose = { (s: String, t: String) =>
+      for {
+        a1 <- getAge(s)
+        a2 <- getAge(t)
+        xs <- range(a1, a2)
+      } yield xs
+    }
+  }
+}
+

--- a/src/main/scala/ListComprehensionNested.scala
+++ b/src/main/scala/ListComprehensionNested.scala
@@ -1,0 +1,175 @@
+package org.hablapps.liq
+
+import scalaz._, Scalaz._
+
+object ListComprehensionNested {
+
+  case class Person(name: String, age: Int)
+  case class Couple(her: Person, him: Person)
+
+  type People = List[Person]
+  type Couples = List[Couple]
+
+  val couples = List(
+    Couple(Person("Alex", 60), Person("Bert", 55)),
+    Couple(Person("Cora", 33), Person("Drew", 31)),
+    Couple(Person("Edna", 21), Person("Fred", 60)))
+
+  object Primitives {
+    
+    // XXX: we assume all people hangs from a couple, which is a different
+    // assumption from the one in `ListComprehension`.
+    val getPeople: People = 
+      couples >>= (c => List(c.her, c.him))
+
+    val getPeopleName: List[String] =
+      getPeople.map(_.name)
+
+    val getPeopleOnTheirThirties: People =
+      for {
+        p <- getPeople
+        if 30 <= p.age && p.age < 40
+      } yield p
+
+    val getHerAges: List[Int] =
+      couples.map(_.her).map(_.age)
+  }
+
+  object QueryViaQuotation {
+    
+    val difference =
+      for {
+        c <- couples
+        if c.her.age > c.him.age
+      } yield (c.her.name, c.her.age - c.him.age)
+  }
+
+  object AbstractingOverValues {
+    import Primitives.getPeople
+
+    val range = { (a: Int, b: Int) =>
+      for {
+        p <- getPeople
+        if a <= p.age && p.age < b
+      } yield p.name
+    }
+
+    range(30, 40)
+  }
+
+  object AbstractingOverAPredicate {
+    import Primitives.getPeople
+
+    val satisfies = { (pred: Int => Boolean) =>
+      for {
+        p <- getPeople
+        if pred(p.age)
+      } yield p.name
+    }
+
+    satisfies(i => 30 <= i && i < 40)
+  }
+
+  object ComposingQueries {
+    import Primitives.getPeople
+    import AbstractingOverValues.range
+    
+    val getAge = { (s: String) =>
+      for {
+        u <- getPeople
+        if u.name == s
+      } yield u.age
+    }
+
+    val compose = { (s: String, t: String) =>
+      for {
+        a1 <- getAge(s)
+        a2 <- getAge(t)
+        xs <- range(a1, a2)
+      } yield xs
+    }
+  }
+
+  object Nested {
+    
+    case class Org(
+      departments: List[Department],
+      employees: List[Employee],
+      tasks: List[Task])
+
+    case class Department(dpt: String)
+
+    case class Employee(dpt: String, emp: String)
+
+    case class Task(emp: String, tsk: String)
+
+    val org: Org = Org(
+      departments = List(
+        Department("Product"), Department("Quality"),
+        Department("Research"), Department("Sales")),
+      employees = List(
+        Employee("Product", "Alex"),
+        Employee("Product", "Bert"),
+        Employee("Research", "Cora"),
+        Employee("Research", "Drew"),
+        Employee("Research", "Edna"),
+        Employee("Sales", "Fred")),
+      tasks = List(
+        Task("Alex", "build"),
+        Task("Bert", "build"),
+        Task("Cora", "abstract"),
+        Task("Cora", "build"),
+        Task("Cora", "design"),
+        Task("Drew", "abstract"),
+        Task("Drew", "design"),
+        Task("Edna", "abstract"),
+        Task("Edna", "call"),
+        Task("Edna", "design"),
+        Task("Fred", "call")))
+
+    def expertise(u: String): List[String] =
+      for {
+        d <- org.departments
+        if (for {
+          e <- org.employees
+          if d.dpt == e.dpt && (for {
+            t <- org.tasks
+            if t.emp == e.emp && t.tsk == u
+          } yield t).isEmpty
+        } yield e).isEmpty
+      } yield d.dpt
+
+    def expertise_(u: String): List[String] =
+      for {
+        d <- org.departments
+        if org.employees.filter(_.dpt == d.dpt).forall { e =>
+          org.tasks.any(t => t.emp == e.emp && t.tsk == u)
+        }
+      } yield d.dpt
+
+
+    /* Nested organization */
+
+    case class NestedOrg(departments: List[NestedDepartment])
+
+    case class NestedDepartment(dpt: String, employees: List[NestedEmployee])
+
+    case class NestedEmployee(emp: String, tasks: List[NestedTask])
+
+    type NestedTask = String
+
+    def nestedOrg: NestedOrg = NestedOrg(
+      org.departments.map { d =>
+        NestedDepartment(d.dpt, org.employees.filter(_.dpt == d.dpt).map { e =>
+          NestedEmployee(e.emp, org.tasks.filter(_.emp == e.emp).map(_.tsk))
+        })
+      })
+
+    def expertise__(u: String): List[String] =
+      for {
+        d <- nestedOrg.departments
+        if d.employees.forall(_.tasks.contains(u))
+      } yield d.dpt
+  }
+}
+

--- a/src/main/scala/Optics.scala
+++ b/src/main/scala/Optics.scala
@@ -105,11 +105,10 @@ object Optics {
   object AbstractingOverValues {
     import Primitives.coupledPeople
 
-    val nameAgeTr = coupledPeople ^|-> name * age
+    val nameAgeTr = (coupledPeople ^|-> name * age).asFold
 
     val rangeFl: (Int, Int) => Fold[Couples, String] = { (a, b) =>
-      nameAgeTr.asFold
-               .withFilter { case (_, i) => a <= i && i < b }
+      nameAgeTr.withFilter { case (_, i) => a <= i && i < b }
                .composeLens(fst)
     }
 
@@ -124,8 +123,7 @@ object Optics {
     import AbstractingOverValues.nameAgeTr
 
     val satisfiesFl: (Int => Boolean) => Fold[Couples, String] = { p =>
-      nameAgeTr.asFold 
-               .withFilter { case (_, a) => p(a) }
+      nameAgeTr.withFilter { case (_, a) => p(a) }
                .composeLens(fst)
     }
 

--- a/src/main/scala/Optics.scala
+++ b/src/main/scala/Optics.scala
@@ -1,0 +1,169 @@
+package org.hablapps.liq
+
+import scalaz.{Lens => _, _}, Scalaz._
+
+import monocle._, macros.Lenses, function.all._
+
+object Optics {
+  
+  @Lenses case class Person(name: String, age: Int)
+  @Lenses case class Couple(her: Person, him: Person)
+
+  type People  = List[Person]
+  type Couples = List[Couple]
+
+  val couples = List(
+    Couple(Person("Alex", 60), Person("Bert", 55)),
+    Couple(Person("Cora", 33), Person("Drew", 31)),
+    Couple(Person("Edna", 21), Person("Fred", 60)))
+
+  import Person.{name, age}, Couple.{her, him}
+
+  val both: Traversal[Couple, Person] = Traversal.applyN(her, him) 
+
+  val all: Traversal[List[Couple], Couple] = each[List[Couple], Couple]
+
+  implicit class TraversalOps[S, A](tr: Traversal[S, A]) {
+
+    def contains(a: A): S => Boolean =
+      tr.exist(_ == a)
+
+    def filter(p: A => Boolean): S => List[A] =
+      tr.foldMap[List[A]](a => if (p(a)) List(a) else List.empty)
+
+    def filterMap[B](p: A => (Boolean, B)): S => List[B] =
+      s => filter(a => p(a)._1)(s).map(a => p(a)._2)
+
+    def filterMap[B](p: A => Boolean)(f: A => B): S => List[B] =
+      filterMap(a => (p(a), f(a)))
+
+    def filterContent(p: A => Boolean): Fold[S, A] =
+      new Fold[S, A] {
+        def foldMap[M: Monoid](f: A => M)(s: S): M = ???
+      }
+  }
+
+  implicit class LensOps[S, A](ln: Lens[S, A]) {
+    // XXX: unlawful when `A` and `B` are pointing to the same value
+    def *[B](other: Lens[S, B]): Lens[S, (A, B)] = 
+      Lens[S, (A, B)](
+        s => (ln.get(s), other.get(s)))(
+        ab => s => other.set(ab._2)(ln.set(ab._1)(s)))
+  }
+
+  object Primitives {
+
+    val coupledPeople: Traversal[Couples, Person] = 
+      all ^|->> both
+
+    val people: Traversal[People, Person] = 
+      each[People, Person]
+    
+    val getPeople: People => People = 
+      people.getAll
+
+    val getPeopleName: People => List[String] =
+      (people ^|-> name).getAll
+
+    val getPeopleOnTheirThirties: People => People =
+      people.filter(p => 30 <= p.age && p.age < 40)
+
+    val getHerAges: Couples => List[Int] =
+      (all ^|-> her ^|-> age).getAll
+  }
+
+  object QueryViaQuotation {
+    
+    val difference: Couples => List[(String, Int)] =
+      all.filterMap { c =>
+        (c.her.age > c.him.age, (c.her.name, c.her.age - c.him.age))
+      }
+
+    val difference2: Couples => List[(String, Int)] =
+      (all ^|-> (him ^|-> age) * (her ^|-> name * age)).filterMap {
+        case (ma, (wn, wa)) => (wa > ma, (wn, wa - ma))
+      }
+  }
+
+  object AbstractingOverValues {
+    import Primitives.coupledPeople
+
+    val range = { (a: Int, b: Int) =>
+      coupledPeople.filterMap { p =>
+        (a <= p.age && p.age < b, p.name)
+      }
+    }
+
+    val nameAge = coupledPeople ^|-> name * age
+
+    val range2: (Int, Int) => Couples => List[String] = { (a, b) =>
+      nameAge.filterMap { case (s, i) =>
+        (a <= i && i < b, s)
+      }
+    }
+
+    range(30, 40)
+  }
+
+  object AbstractingOverAPredicate {
+    import AbstractingOverValues.nameAge
+
+    val satisfies = { (pred: Int => Boolean) =>
+      (all ^|->> both).filterMap(p => (pred(p.age), p.name))
+    }
+
+    val satisfies2: (Int => Boolean) => Couples => List[String] = { p =>
+      nameAge.filterMap { case (n, a) => (p(a), n) }
+    }
+
+    satisfies(i => 30 <= i && i < 40)
+  }
+
+  object ComposingQueries {
+    import AbstractingOverValues.range
+    import AbstractingOverValues.nameAge
+    
+    val getAge = { (s: String) =>
+      (all ^|->> both).filterMap(p => (p.name == s, p.age))
+    }
+
+    val getAge2: String => Couples => List[Int] = { (s: String) =>
+      nameAge.filterMap { case (n, a) => (n == s, a) }
+    }
+
+    // XXX: filtering by content should be safe for `Fold`s. Check it!
+    def getAge3(s: String): Fold[Couples, Int] =
+      all.composeTraversal(both).filterContent(_.name == s).composeLens(age)
+
+    // XXX: we should be composing optics instead of Options, this isn't valid!
+    val compose = { (s: String, t: String) => (c: Couples) =>
+      (getAge(s)(c).headOption |@| getAge(t)(c).headOption)(range(_, _))
+    }
+
+    val compose2 = { (s: String, t: String) => (c: Couples) =>
+      (getAge3(s).headOption(c) |@| getAge3(t).headOption(c))(range(_, _))
+    }
+  }
+
+  object Nested {
+
+    @Lenses case class NestedOrg(departments: List[NestedDepartment])
+
+    @Lenses case class NestedDepartment(dpt: String, employees: List[NestedEmployee])
+
+    @Lenses case class NestedEmployee(emp: String, tasks: List[NestedTask])
+
+    type NestedTask = String
+
+    import NestedOrg._, NestedDepartment._, NestedEmployee._
+
+    val eachDpt = departments ^|->> each
+    val eachEmp = employees ^|->> each
+    val eachTsk = tasks ^|->> each
+
+    // XXX: we use optics, but we don't compose them. So weird!
+    def expertise(u: String): NestedOrg => List[String] =
+      eachDpt.filterMap(eachEmp.all(eachTsk.contains(u)))(_.dpt)
+  }
+}
+

--- a/src/main/scala/OpticsTypeclass.scala
+++ b/src/main/scala/OpticsTypeclass.scala
@@ -1,0 +1,138 @@
+package org.hablapps.liq
+
+import monocle._
+
+object OpticsTypeclas {
+  import Optics._
+
+  trait LensHom[Alg[_], S] {
+    type A
+    val alg: Alg[A]
+    def apply(): Lens[S, A]
+  }
+
+  trait TraversalHom[Alg[_], S] {
+    type A
+    val alg: Alg[A]
+    def apply(): Traversal[S, A]
+  }
+
+  trait Person[S] {
+    val name: Lens[S, String]
+    val age:  Lens[S, Int]
+  }
+
+  trait Couple[S] {
+    val her: LensHom[Person, S]
+    val him: LensHom[Person, S]
+  }
+
+  object Primitives {
+     
+    def getPeople[S](tr: TraversalHom[Person, S]): S => List[tr.A] =
+      s => tr().getAll(s)
+
+    def getPeopleName[S](tr: TraversalHom[Person, S]): S => List[String] = {
+      import tr.alg.name
+      (tr() ^|-> name).getAll
+    }
+
+    def getPeopleOnTheirThirtiesFl[S](
+        tr: TraversalHom[Person, S]): Fold[S, tr.A] = {
+      import tr.alg.age
+      tr().asFold.withFilter(p => 30 <= age.get(p) && age.get(p) < 40)
+    }
+
+    def getPeopleOnTheirThirties[S](
+        tr: TraversalHom[Person, S]): S => List[tr.A] =
+      s => getPeopleOnTheirThirtiesFl(tr).getAll(s)
+
+    def getHerAges[S](tr: TraversalHom[Couple, S]): S => List[Int] = {
+      import tr.alg.her, her.alg.age
+      (tr() ^|-> her() ^|-> age).getAll 
+    }
+  }
+
+  object QueryViaQuotation {
+
+    def differenceFl[S](
+        tr: TraversalHom[Couple, S]): Fold[S, (String, Int)] = {
+      import tr.alg.{her, him}
+      import her.alg.{age => herAge, name => herName}, him.alg.{age => himAge}
+      (tr() ^|-> (him() ^|-> himAge) * (her() ^|-> herName * herAge) ^<-> flat)
+        .asFold
+        .withFilter { case (ma, _, wa) => wa > ma } 
+        .withMap { case (ma, wn, wa) => (wn, wa - ma) }
+    }
+
+    def difference[S](
+        tr: TraversalHom[Couple, S]): S => List[(String, Int)] = 
+      differenceFl(tr).getAll
+
+    // difference(couples)
+  }
+
+  object AbstractingOverValues {
+
+    // XXX: If we use Couples as root this becomes a nightmare, because we
+    // can't reuse optics. Thereby, I can't define the Traversal with both.
+    
+    def nameAgeFl[S](
+        tr: TraversalHom[Person, S]): Fold[S, (String, Int)] = {
+      import tr.alg.{name, age}
+      (tr() ^|-> name * age).asFold
+    }
+
+    def rangeFl[S](
+        tr: TraversalHom[Person, S])(
+        a: Int, b: Int): Fold[S, String] =
+      nameAgeFl(tr).withFilter { case (_, i) => a <= i && i < b }
+                   .composeLens(fst)
+
+    def range[S](
+        tr: TraversalHom[Person, S])(
+        a: Int, b: Int): S => List[String] =
+      rangeFl(tr)(a, b).getAll
+  }
+
+  object AbstractingOverAPredicate {
+    import AbstractingOverValues.nameAgeFl
+
+    def satisfiesFl[S](
+        tr: TraversalHom[Person, S])(
+        p: Int => Boolean): Fold[S, String] =
+      nameAgeFl(tr).withFilter { case (_, a) => p(a) }
+                   .composeLens(fst)
+
+    def satisfies[S](
+        tr: TraversalHom[Person, S])(
+        p: Int => Boolean): S => List[String] =
+      satisfiesFl(tr)(p).getAll
+  }
+
+  object ComposingQueries {
+    import AbstractingOverValues.rangeFl
+
+    def getAgeFl[S](
+        tr: TraversalHom[Person, S])(
+        s: String): Fold[S, Int] = {
+      import tr.alg.{age, name}
+      tr().asFold
+          .withFilter(name.get(_) == s)
+          .composeLens(age)
+    }
+
+    def composeFl[S](
+        tr: TraversalHom[Person, S])(
+        s: String, t: String): Fold[S, String] =
+      (getAgeFl(tr)(s) * getAgeFl(tr)(t)).flatMap { 
+        case (a, b) => rangeFl(tr)(a, b)
+      }
+
+    def compose[S](
+        tr: TraversalHom[Person, S])(
+        s: String, t: String): S => List[String] =
+      composeFl(tr)(s, t).getAll
+  }
+}
+


### PR DESCRIPTION
Contains the implementation of the LIQ's paper examples using plain list-comprehensions and optics. For the latter, we've added new combinators in order to delay the invocation of the actions as much as possible.